### PR TITLE
fix "ofxOpenCv" dependency casing

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -26,7 +26,7 @@ common:
 	# or use += in several lines
 	# NOTE - we only include ofxKinect as it's the easiest way to ensure libusb
 	# is included cross platform
-	ADDON_DEPENDENCIES = ofxXmlSettings ofxGui ofxOpenCV ofxNetwork ofxPoco ofxSvg ofxKinect
+	ADDON_DEPENDENCIES = ofxXmlSettings ofxGui ofxOpenCv ofxNetwork ofxPoco ofxSvg ofxKinect
 	
 	# include search paths, this will be usually parsed from the file system
 	# but if the addon or addon libraries need special search paths they can be


### PR DESCRIPTION
Without this change, projectGenerator throws an error saying it cannot find ````ofxOpenCV```` when trying to update the ofxLaser examples.

I've confirmed on OF 0.10.1 and 0.11, the addon is ````ofxOpenCv````, not ````ofxOpenCV```` - a slight difference in capitalization of the final letter v.

Making this change resolved the complaints from projectGenerator.