### PR TITLE
comment out #include "HeliosDac.h"

### DIFF
--- a/example_RollingShutter/src/ofApp.h
+++ b/example_RollingShutter/src/ofApp.h
@@ -8,7 +8,7 @@
 
 #include "ofxGui.h"
 
-#include "HeliosDac.h"
+//#include "HeliosDac.h"
 
 #define USE_ETHERDREAM
 //#define USE_IDN


### PR DESCRIPTION
This file appears not to be included with ofxLaser, and it throws an error during build. Perhaps this was left in from some testing, or part of a future update?